### PR TITLE
Fix centering

### DIFF
--- a/app/pages/home.less
+++ b/app/pages/home.less
@@ -1,6 +1,6 @@
 .home-page {
   text-align: center;
-  
+
   .atx {
     width: 128px;
   }

--- a/app/pytx.less
+++ b/app/pytx.less
@@ -20,14 +20,19 @@ body {
   height: 100vh;
 }
 
-.main-panel {
-  padding-left: 95px;
-  padding-right: 10px;
+#content {
+  display: flex;
+}
 
-  @media @for-phone {
-    padding-left: 0;
-    padding-right: 0;
-  }
+#content::after {
+  content: "";
+  flex: 1;
+  min-width: @leftNavWidth;
+}
+
+.main-panel {
+  flex: 1;
+  flex-grow: 100;
 }
 
 h1,

--- a/app/pytx.less
+++ b/app/pytx.less
@@ -24,15 +24,11 @@ body {
   display: flex;
 }
 
-#content::after {
-  content: "";
-  flex: 1;
-  min-width: @leftNavWidth;
-}
-
 .main-panel {
   flex: 1;
   flex-grow: 100;
+  padding-right: 100px;
+  min-width: @desktopBreak;
 }
 
 h1,

--- a/app/pytx.less
+++ b/app/pytx.less
@@ -23,7 +23,7 @@ body {
 .main-panel {
   padding-left: 95px;
   padding-right: 10px;
-  
+
   @media @for-phone {
     padding-left: 0;
     padding-right: 0;
@@ -42,7 +42,7 @@ h6 {
 .md-card {
   max-width: 865px;
   margin: 0 auto;
-  
+
   @media @for-phone {
     margin: 0;
     width: 100vw;

--- a/app/widgets/left-nav.less
+++ b/app/widgets/left-nav.less
@@ -49,9 +49,8 @@
   }
 
   .md-button {
-    width: 100%;
     height: 100%;
-    margin: 3px 0;
+    margin: 0 0;
     padding: 0;
     color: @accentColor;
     font-size: 0.8rem;

--- a/app/widgets/left-nav.less
+++ b/app/widgets/left-nav.less
@@ -2,11 +2,9 @@
 @import "styles";
 
 .leftnav-wrapper {
-  position: fixed;
-  margin-top: -7px;
-  margin-left: 5px;
-  width: 90px;
-  height: ~"calc(100vh - 68px)";
+  flex: 1;
+  padding: 5px;
+  min-width: @leftNavWidth;
 
   .md-list-item-container {
     padding: 0;
@@ -19,9 +17,11 @@
 
   .md-list.md-theme-default {
     display: flex;
-    height: 100%;
+    position: fixed;
+    height: ~"calc(100vh - 68px)";
     max-height: 440px;
     background-color: transparent;
+    padding: 0;
 
     .md-list-item {
       flex: 1;

--- a/app/widgets/left-nav.less
+++ b/app/widgets/left-nav.less
@@ -6,48 +6,48 @@
   margin-top: -7px;
   margin-left: 5px;
   width: 90px;
-  height: ~'calc(100vh - 68px)';
-  
+  height: ~"calc(100vh - 68px)";
+
   .md-list-item-container {
     padding: 0;
     margin: 0;
   }
-  
+
   @media @for-phone {
-    display: none
+    display: none;
   }
-  
+
   .md-list.md-theme-default {
     display: flex;
     height: 100%;
     max-height: 440px;
     background-color: transparent;
-    
+
     .md-list-item {
       flex: 1;
-      
+
       .md-icon:first-of-type + * {
         flex: none;
       }
-      
+
       .router-link-active.md-list-item-container {
         color: @accentColor;
       }
-      
+
       .md-button.txicon .md-icon {
         margin: 0;
       }
     }
-    
+
     .md-list-item-container {
       height: 100%;
-      
+
       & > .md-icon:first-child {
         margin: 0;
       }
     }
   }
-  
+
   .md-button {
     width: 100%;
     height: 100%;
@@ -61,7 +61,7 @@
     flex-direction: column;
     justify-content: center;
   }
-  
+
   .md-icon {
     path {
       fill: @accentColor;

--- a/less/media.less
+++ b/less/media.less
@@ -1,2 +1,4 @@
+@import "media";
+
 @for-phone: ~"screen and (max-width: 44.9375rem)"; // < 720
-@for-desktop: ~"screen and (min-width: 45rem)"; // > 720
+@for-desktop: ~"screen and (min-width: @desktopBreak)"; // > 720

--- a/less/styles.less
+++ b/less/styles.less
@@ -15,3 +15,4 @@
 @headerFont: "Roboto Slab", serif;
 
 @leftNavWidth: 100px;
+@desktopBreak: 45rem;

--- a/less/styles.less
+++ b/less/styles.less
@@ -13,3 +13,5 @@
 
 @bodyFont: "Roboto", sans-serif;
 @headerFont: "Roboto Slab", serif;
+
+@leftNavWidth: 100px;


### PR DESCRIPTION
Removing the flexbox stuff in 836052e4f21a7ba08ac85ca315ec5dc164907951 made the `main-panel` sit off-center.

This PR adds it back in, and keeps everything else looking the same as before.

| Before | After |
| - | - |
| <img width="1440" alt="screen shot 2017-09-07 at 10 49 10 am" src="https://user-images.githubusercontent.com/294415/30172364-466ebb76-93ba-11e7-9404-1a512d1986a1.png"> | <img width="1440" alt="screen shot 2017-09-07 at 10 48 54 am" src="https://user-images.githubusercontent.com/294415/30172363-466d3a30-93ba-11e7-9275-4e56721152e8.png"> |
