### PR TITLE
Set nav element width

### DIFF
--- a/app/widgets/sub-nav.less
+++ b/app/widgets/sub-nav.less
@@ -8,6 +8,10 @@
     @media @for-desktop {
       margin-top: 10px;
     }
+
+    div nav {
+      width: 100%;
+    }
   }
 
   .md-tabs-content {


### PR DESCRIPTION
This fixes an issue with the `nav` element having a default width of 720px and rendering incorrectly on some smaller screens:

![screenshot_20171030-222407](https://user-images.githubusercontent.com/294415/32284424-33c0b72a-bef5-11e7-8933-736473ff6465.png)
